### PR TITLE
fix(font-symbol-size): add willReadFrequently to avoid warning

### DIFF
--- a/src/font/font-symbol-size.js
+++ b/src/font/font-symbol-size.js
@@ -23,7 +23,7 @@ const symbolSize = function(id){
     const canvaser = document.createElement("canvas");
     canvaser.width = bound;
     canvaser.height = bound;
-    context = canvaser.getContext("2d"); 
+    context = canvaser.getContext("2d", {willReadFrequently: true}); 
   }
   context.clearRect(0, 0, bound, bound);
   context.font = (30*zoom) + "px 'SuttonSignWritingLine'";


### PR DESCRIPTION
Currently seeing in the console:
> Canvas2D: Multiple readback operations using getImageData are faster with the willReadFrequently attribute set to true. See: https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently